### PR TITLE
load required .js files correctly

### DIFF
--- a/src/system.js
+++ b/src/system.js
@@ -243,9 +243,15 @@
         }
       }
 
-      var outPath = this.paths[pathMatch];
-      if (wildcard)
-        outPath = outPath.replace('*', wildcard);
+				var ext = wildcard.match(/\.(\w+)$/);
+				var outPath = this.paths[pathMatch];
+				if (wildcard) {
+					if(!ext || (ext && '*'+ext[0] !== outPath)){
+						outPath = outPath.replace('*', wildcard);
+					}else{
+						outPath = wildcard;
+					}
+				}
 
       // percent encode just '#' in module names
       // according to https://github.com/jorendorff/js-loaders/blob/master/browser-loader.js#L238

--- a/src/system.js
+++ b/src/system.js
@@ -198,8 +198,35 @@
           throw new TypeError('Illegal module name "' + name + '"');
       }
 
-      if (!rel)
+      if (!rel) {
         return name;
+      }else{
+        var lastSegment = segments.pop();
+        // Detech if this name contains a plugin part like: app.less!steal/less
+        // and catch the plugin name so that when it is normalized we do not perform
+        // Steal's normalization against it.
+        var pluginIndex = lastSegment.lastIndexOf('!');
+        var pluginPart = "";
+        if (pluginIndex != -1) {
+          // argumentName is the part before the !
+          var argumentName = lastSegment.substr(0, pluginIndex);
+          var pluginName = lastSegment.substr(pluginIndex + 1);
+          pluginPart = "!" + pluginName;
+
+          lastSegment = argumentName;
+        }
+
+        var dot = lastSegment.lastIndexOf(".");
+        if(dot !== -1) {
+          extension = lastSegment.substr(dot+1);
+        }
+
+        if(extension === "js") {
+          segments.push(lastSegment.substr(0, segment.lastIndexOf(".")) + pluginPart);
+        } else {
+          segments.push(lastSegment + pluginPart);
+        }
+      }
 
       // build the full module name
       var normalizedParts = [];
@@ -243,15 +270,9 @@
         }
       }
 
-				var ext = wildcard.match(/\.(\w+)$/);
-				var outPath = this.paths[pathMatch];
-				if (wildcard) {
-					if(!ext || (ext && '*'+ext[0] !== outPath)){
-						outPath = outPath.replace('*', wildcard);
-					}else{
-						outPath = wildcard;
-					}
-				}
+      var outPath = this.paths[pathMatch];
+      if (wildcard)
+        outPath = outPath.replace('*', wildcard);
 
       // percent encode just '#' in module names
       // according to https://github.com/jorendorff/js-loaders/blob/master/browser-loader.js#L238

--- a/src/system.js
+++ b/src/system.js
@@ -201,12 +201,14 @@
       if (!rel) {
         return name;
       }else{
-        var lastSegment = segments.pop();
-        // Detech if this name contains a plugin part like: app.less!steal/less
-        // and catch the plugin name so that when it is normalized we do not perform
-        // Steal's normalization against it.
-        var pluginIndex = lastSegment.lastIndexOf('!');
-        var pluginPart = "";
+        var extension,
+            lastSegment = segments.pop(),
+            // Detech if this name contains a plugin part like: app.less!steal/less
+            // and catch the plugin name so that when it is normalized we do not perform
+            // Steal's normalization against it.
+            pluginIndex = lastSegment.lastIndexOf('!'),
+            pluginPart = "";
+
         if (pluginIndex != -1) {
           // argumentName is the part before the !
           var argumentName = lastSegment.substr(0, pluginIndex);


### PR DESCRIPTION
closes https://github.com/stealjs/steal/issues/606

the second PR is a better fix for the issue.
now the modules are loaded only once

for example:

```
var MySalute = require("./salute.js");
```

and

```
var MySalute = require("path/to/salute");
```

with this fix, only relative required path can be resolved correctly. a absolute path must not have a `.js` extension in the path.
also mapped files must not have a `.js` extension in the path
