### PR TITLE
delete deprecated babel option

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -92,6 +92,10 @@
     if(!babelVersion) babelVersion = 6;
 
     if(babelVersion >= 6) {
+      // delete the old babel options if they are present in config
+      delete options.optional;
+      delete options.whitelist;
+      delete options.blacklist;
       // If the user didn't provide presets/plugins, use the defaults
       if(!options.presets && !options.plugins) {
         options.presets = [


### PR DESCRIPTION
delete deprecated babel option if we are using babel 6, so not error will be thrown by babel anymore
https://github.com/stealjs/steal/issues/772

@matthewp i think we can merge that without release steal 1.0. steal 0.16 will be work with that PR also
